### PR TITLE
minor - fix docs so explanation of skipIf stays with skipIf

### DIFF
--- a/src/action/action.ts
+++ b/src/action/action.ts
@@ -646,10 +646,10 @@ export default class Action<P extends Player, A extends Record<string, Argument<
    * @param options.max - If supplied, the choice is for a *set* of
    * elements and the maximum allowed is `max`.
    *
+   * @param options.initial - Optional list of game elements to be preselected
+   *
    * @param options.skipIf - One of 'always', 'never' or 'only-one' or a
    * function returning a boolean. (Default 'only-one').
-   *
-   * @param options.initial - Optional list of game elements to be preselected
    *
    * <ul>
    * <li>only-one: If there is only valid choice in the choices given, the game


### PR DESCRIPTION
the docs for the new "initial" landed in the middle of the skipIf, resulting in confusing docs.